### PR TITLE
Fix of #98: watchVueFiles is not defined

### DIFF
--- a/generators/vuejs/templates/gulpfile.js
+++ b/generators/vuejs/templates/gulpfile.js
@@ -70,5 +70,3 @@ gulp.watch('./src/**/*.vue', event => {
         .pipe(gulp.dest('./src/'));
 
 });
-
-build.rig.addPreBuildTask(watchVueFiles);


### PR DESCRIPTION
#### Category
- [ ] New Feature
- [ ] New Framework
- [x] Bugfix
- [ ] Documentation fixed
- Related issues: #98 

#### What's in this Pull Request?

Fix of #98. Removed the line `build.rig.addPreBuildTask(watchVueFiles);` from VueJS `gulpfile.js`.