### PR TITLE
Typo in command-line param

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -289,7 +289,7 @@ module.exports = class extends Generator {
             type: String
         });
 
-        this.option('enviroment', {
+        this.option('environment', {
             description: `The target environment for the solution:
                                         - "onprem"
                                         - "onprem19"


### PR DESCRIPTION
#### Category
- [ ] New Feature
- [ ] New Framework
- [x] Bugfix
- [ ] Documentation fixed
- Related issues: fixes #166


#### What's in this Pull Request?

Typo in command line parameter "enviroment"


