### PR TITLE
Add support for microsoft/generator-sharepoint 1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # PnP SPFx generator - community driven and open source
 
-Tests: [![CircleCI](https://circleci.com/gh/pnp/generator-spfx.svg?style=svg)](https://circleci.com/gh/pnp/generator-spfx)
-
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/generator-spfx/generator)
+[![CircleCI](https://circleci.com/gh/pnp/generator-spfx.svg?style=shield)](https://circleci.com/gh/pnp/generator-spfx) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/generator-spfx/generator)
 
 
 This Yeoman generator provides improved governance for SharePoint Framework projects. It extends the out of the box Yeoman generator from Microsoft (@microsoft/generator-sharepoint) with recommended patterns and additional capabilities.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # PnP SPFx generator - community driven and open source
 
+Tests: [![CircleCI](https://circleci.com/gh/pnp/generator-spfx.svg?style=svg)](https://circleci.com/gh/pnp/generator-spfx)
+
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/generator-spfx/generator)
+
+
 This Yeoman generator provides improved governance for SharePoint Framework projects. It extends the out of the box Yeoman generator from Microsoft (@microsoft/generator-sharepoint) with recommended patterns and additional capabilities.
  
 For an optimized development workflow, it extends the capabilities for ReactJS, and Knockout projects and support for additional frameworks, such as HandlebarsJS, VueJS and Angular Elements. It also includes includes advanced code analysis and testing tools, which you can take advantage in you development work.

--- a/app/index.js
+++ b/app/index.js
@@ -161,9 +161,10 @@ module.exports = class extends Generator {
 
             switch (item) {
                 case "jquery":
-                    if (selections.jQueryVersion !== undefined) {
-                        item = `${item}@${selections.jQueryVersion}`
-                    }
+                    // Disabled because jQuery2 is deprecated
+                    // if (selections.jQueryVersion !== undefined) {
+                    //     item = `${item}@${selections.jQueryVersion}`
+                    // }
                     break;
                 default:
                     break;

--- a/generators/addons/promptConfig.js
+++ b/generators/addons/promptConfig.js
@@ -40,7 +40,7 @@ const ciOptions = [
 // SharePoint Online supported libraries
 const spoLibs = [{
         name: 'jQuery',
-        value: 'jquery'
+        value: 'jquery@3'
     }, {
         name: 'pnpjs',
         value: '@pnp/pnpjs'
@@ -97,14 +97,15 @@ const configOptions = [
         }
     },
     // jQuery version selection
-    {
-        type: 'list',
-        message: `${chalk.bold.yellow('jQuery: ')} Please choose a version:`,
-        name: 'jQueryVersion',
-        choices: jqueryOptions,
-        // Show only when jQuery was included
-        when: answers => answers.jsLibrary !== undefined && answers.jsLibrary.indexOf('jquery') !== -1
-    },
+    // Disables since nobody uses it
+    // {
+    //     type: 'list',
+    //     message: `${chalk.bold.yellow('jQuery: ')} Please choose a version:`,
+    //     name: 'jQueryVersion',
+    //     choices: jqueryOptions,
+    //     // Show only when jQuery was included
+    //     when: answers => answers.jsLibrary !== undefined && answers.jsLibrary.indexOf('jquery') !== -1
+    // },
     // Vetting and code style options
     {
         type: 'checkbox',

--- a/generators/addons/templates/addonConfig.json
+++ b/generators/addons/templates/addonConfig.json
@@ -7,7 +7,7 @@
     },
     "jquery@3": {
         "dependencies": {
-            "jquery": "^3.3.1",
+            "jquery": "^3.4.1",
             "@types/jquery": "^3.3.29"
         }
     },
@@ -23,7 +23,7 @@
     },
     "@pnp/spfx-controls-react": {
         "dependencies": {
-            "@pnp/spfx-controls-react": "1.12.0"
+            "@pnp/spfx-controls-react": "1.13.0"
         }
     },
     "webpack-analyzer": {
@@ -34,8 +34,8 @@
     "stylelint": {
         "devDependencies": {
             "stylelint": "^9.10.1",
-            "stylelint-config-standard": "^18.2.0",
-            "stylelint-scss": "^3.5.4",
+            "stylelint-config-standard": "^18.3.0",
+            "stylelint-scss": "^3.6.1",
             "gulp-stylelint": "^8.0.0"
         }
     },

--- a/generators/vuejs/index.js
+++ b/generators/vuejs/index.js
@@ -12,7 +12,6 @@ module.exports = class extends Generator {
     constructor(args, opts) {
 
         super(args, opts);
-        // configuration of user prompt
 
     }
 
@@ -65,6 +64,28 @@ module.exports = class extends Generator {
     }
 
     _deployFiles() {
+
+        console.log('Environment::::', this);
+
+        console.log('Environment::::', this.options.SpfxOptions.environment)
+
+        if(this.options !== undefined &&
+            this.options.SpfxOptions !== undefined &&
+            this.options.SpfxOptions.environment !== undefined &&
+            this.options.SpfxOptions.environment === "spo"){
+
+                // First remove the old tsconfig file
+                if(fs.existsSync(this.destinationPath('tsconfig.json'))){
+                    fs.unlinkSync(this.destinationPath('tsconfig.json'));
+                }
+
+                // add new tsconfig file  for VueJS spo projects
+                this.fs.copy(
+                    this.templatePath('tsconfig.json'),
+                    this.destinationPath('tsconfig.json')
+                )
+
+            }
 
         this.fs.copy(
             this.templatePath('config/copy-static-assets.json'),

--- a/generators/vuejs/templates/addonConfig.json
+++ b/generators/vuejs/templates/addonConfig.json
@@ -10,7 +10,7 @@
             "vue-template-compiler": "^2.6.10",
             "sass-loader": "^7.1.0",
             "ts-loader": "^5.3.3",
-            "fork-ts-checker-webpack-plugin": "^1.0.3"
+            "fork-ts-checker-webpack-plugin": "^1.3.0"
         }
     }
 }

--- a/generators/vuejs/templates/tsconfig.json
+++ b/generators/vuejs/templates/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "extends": "./node_modules/@microsoft/rush-stack-compiler-2.9/includes/tsconfig-web.json",
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "outDir": "lib",
+    "inlineSources": false,
+    "strictNullChecks": false,
+    "noUnusedLocals": false,
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/@microsoft",
+      "./types"
+    ],
+    "types": [
+      "es6-promise",
+      "webpack-env"
+    ],
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.collection"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "types/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
     "requires": true,
     "dependencies": {
         "@microsoft/generator-sharepoint": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/generator-sharepoint/-/generator-sharepoint-1.8.1.tgz",
-            "integrity": "sha512-XDqjPrgVsuf13ui2eqva1Iwc+BEZGAo4/1fccWqfAA5VTLa9X1+9ipjR6dk0EzOIvWrgg1KKfeSEOEogvobXTw==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/generator-sharepoint/-/generator-sharepoint-1.8.2.tgz",
+            "integrity": "sha512-0hMmPLJT+WXJbFUnUca8nTXzQBiXQ2Mt6zQh30CZoq5+Lnj71V7kJ3v18D6n90In/sJwuoi6au7n5+H9/DTjXA==",
             "requires": {
-                "@microsoft/node-core-library": "3.10.0",
+                "@microsoft/node-core-library": "3.13.0",
                 "@types/es6-promise": "0.0.33",
                 "@types/node": "8.5.8",
                 "argparse": "~1.0.7",
@@ -49,7 +49,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
                         "ansi-styles": "^2.2.1",
@@ -100,7 +100,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 },
                 "package-json": {
@@ -116,7 +116,7 @@
                 },
                 "update-notifier": {
                     "version": "1.0.3",
-                    "resolved": "http://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
                     "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
                     "requires": {
                         "boxen": "^0.6.0",
@@ -195,9 +195,9 @@
             }
         },
         "@microsoft/node-core-library": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.10.0.tgz",
-            "integrity": "sha512-1SbU+XNYAabhV9noGXHtsUVPc5ELV+oEuJQtZQoCncbOd6WAMeTgB1xFwh96hmdEXyKQyML/pnByiKocmh/nbQ==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.13.0.tgz",
+            "integrity": "sha512-mnsL/1ikVWHl8sPNssavaAgtUaIM3hkQ8zeySuApU5dNmsMPzovJPfx9m5JGiMvs1v5QNAIVeiS9jnWwe/7anw==",
             "requires": {
                 "@types/fs-extra": "5.0.4",
                 "@types/jju": "~1.4.0",
@@ -236,9 +236,9 @@
             "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
         },
         "@pnp/office365-cli": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@pnp/office365-cli/-/office365-cli-1.17.0.tgz",
-            "integrity": "sha512-zbmNEVnVlZ2aQwQikKOmlKTiVVX9in+BHkicMPWABYqWb5gq1jnaQreBYXA2nYgbP/nh+3NXSRBPKfKRrZYTnQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@pnp/office365-cli/-/office365-cli-1.18.0.tgz",
+            "integrity": "sha512-YHDxXfHS59hcjgWRdyM+d5xxnfjpKO+maNPK7+yjr0FVZ0s4Ptb6DgOAu8ccvicEM4H3/l9CasnizmpsCqum6g==",
             "requires": {
                 "adal-node": "^0.1.28",
                 "applicationinsights": "^1.1.0",
@@ -5045,7 +5045,7 @@
         },
         "ansi-escapes": {
             "version": "1.4.0",
-            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
             "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "ansi-regex": {
@@ -5235,7 +5235,7 @@
         },
         "bl": {
             "version": "1.2.2",
-            "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "requires": {
                 "readable-stream": "^2.3.5",
@@ -5389,7 +5389,7 @@
         },
         "camelcase-keys": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "requires": {
                 "camelcase": "^2.0.0",
@@ -6055,7 +6055,7 @@
         },
         "external-editor": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
             "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
             "requires": {
                 "extend": "^3.0.0",
@@ -6330,7 +6330,7 @@
         },
         "globby": {
             "version": "4.1.0",
-            "resolved": "http://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
             "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
             "requires": {
                 "array-union": "^1.0.1",
@@ -6357,7 +6357,7 @@
         },
         "got": {
             "version": "5.7.1",
-            "resolved": "http://registry.npmjs.org/got/-/got-5.7.1.tgz",
+            "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
             "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
             "requires": {
                 "create-error-class": "^3.0.1",
@@ -6537,7 +6537,7 @@
         },
         "inquirer": {
             "version": "1.2.3",
-            "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
             "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
             "requires": {
                 "ansi-escapes": "^1.1.0",
@@ -6558,7 +6558,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
                         "ansi-styles": "^2.2.1",
@@ -6873,9 +6873,9 @@
             "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
         },
         "js-yaml": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -6916,7 +6916,7 @@
         },
         "lazy-req": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
             "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
         },
         "lcid": {
@@ -6930,7 +6930,7 @@
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -6981,7 +6981,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
                         "ansi-styles": "^2.2.1",
@@ -7124,7 +7124,7 @@
         },
         "meow": {
             "version": "3.7.0",
-            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "requires": {
                 "camelcase-keys": "^2.0.0",
@@ -7141,7 +7141,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
             }
@@ -7222,9 +7222,9 @@
             }
         },
         "mocha": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.3.tgz",
-            "integrity": "sha512-QdE/w//EPHrqgT5PNRUjRVHy6IJAzAf1R8n2O8W8K2RZ+NbPfOD5cBDp+PGa2Gptep37C/TdBiaNwakppEzEbg==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+            "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -7236,7 +7236,7 @@
                 "glob": "7.1.3",
                 "growl": "1.10.5",
                 "he": "1.2.0",
-                "js-yaml": "3.13.0",
+                "js-yaml": "3.13.1",
                 "log-symbols": "2.2.0",
                 "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
@@ -7398,7 +7398,7 @@
         },
         "node-status-codes": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
             "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
         },
         "normalize-package-data": {
@@ -7512,12 +7512,12 @@
         },
         "onetime": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
             "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-locale": {
@@ -7807,7 +7807,7 @@
         },
         "pretty-bytes": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
             "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
             "requires": {
                 "number-is-nan": "^1.0.0"
@@ -8347,7 +8347,7 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "stack-chain": {
@@ -8381,7 +8381,7 @@
         },
         "string-width": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
                 "code-point-at": "^1.0.0",
@@ -8399,7 +8399,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "^2.0.0"
@@ -8462,7 +8462,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
             }
@@ -8874,7 +8874,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
                 "string-width": "^1.0.1",
@@ -9106,7 +9106,7 @@
         },
         "yeoman-environment": {
             "version": "1.6.6",
-            "resolved": "http://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+            "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
             "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
             "requires": {
                 "chalk": "^1.0.0",
@@ -9125,7 +9125,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
                         "ansi-styles": "^2.2.1",
@@ -10173,7 +10173,7 @@
             "dependencies": {
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
                         "ansi-styles": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
         }
     ],
     "dependencies": {
-        "@microsoft/generator-sharepoint": "1.8.1",
-        "@pnp/office365-cli": "^1.17.0",
+        "@microsoft/generator-sharepoint": "1.8.2",
+        "@pnp/office365-cli": "^1.19.0",
         "applicationinsights": "^1.3.1",
         "chalk": "^2.4.2",
         "command-exists": "^1.2.8",
@@ -79,7 +79,7 @@
         "yeoman-generator": "~3.2.0"
     },
     "devDependencies": {
-        "mocha": "~6.1.3",
+        "mocha": "~6.1.4",
         "rimraf": "^2.6.3",
         "yeoman-assert": "~3.1.1",
         "yeoman-test": "~1.9.1"

--- a/tools/reference-check/addons/package.json
+++ b/tools/reference-check/addons/package.json
@@ -8,13 +8,13 @@
     },
     "license": "MIT",
     "dependencies": {
-        "@pnp/pnpjs": "^1.3.0",
+        "@pnp/pnpjs": "^1.3.2",
         "@pnp/spfx-property-controls": "1.14.1",
-        "@pnp/spfx-controls-react": "1.12.0",
-        "webpack-bundle-analyzer": "^3.1.0",
+        "@pnp/spfx-controls-react": "1.13.0",
+        "webpack-bundle-analyzer": "^3.3.2",
         "stylelint": "^9.10.1",
-        "stylelint-config-standard": "^18.2.0",
-        "stylelint-scss": "^3.5.4",
+        "stylelint-config-standard": "^18.3.0",
+        "stylelint-scss": "^3.6.1",
         "gulp-stylelint": "^8.0.0",
         "gulp-sequence": "1.0.0"
     }

--- a/tools/reference-check/package.json
+++ b/tools/reference-check/package.json
@@ -8,33 +8,30 @@
     },
     "license": "MIT",
     "dependencies": {
-        "jquery": "^2.2.4",
-        "@types/jquery": "^2.0.49",
 
-        "@pnp/spfx-property-controls": "1.12.0",
-        "jquery": "^3.3.1",
-        "@types/jquery": "^3.3.27",
-        "@pnp/pnpjs": "^1.2.7",
-        "@pnp/spfx-property-controls": "1.14.0",
-        "@pnp/spfx-controls-react": "1.11.0",
+        "@pnp/spfx-property-controls": "1.14.1",
+        "jquery": "^3.4.1",
+        "@types/jquery": "^3.3.29",
+        "@pnp/pnpjs": "^1.3.2",
+        "@pnp/spfx-controls-react": "1.13.0",
 
 
-        "vue": "^2.5.21",
+        "vue": "^2.6.10",
         "vue-class-component": "^6.3.2",
         "vue-property-decorator": "^7.2.0",
         "sass-loader": "^7.1.0",
 
-        "handlebars": "^4.0.12"
+        "handlebars": "^4.1.2"
     },
     "devDependencies": {
 
         "sass-loader": "^7.1.0",
         "ts-loader": "^5.3.1",
         "fork-ts-checker-webpack-plugin": "^0.5.2",
-        "vue-loader": "^15.4.2",
-        "vue-template-compiler": "^2.5.21",
+        "vue-loader": "^15.7.0",
+        "vue-template-compiler": "^2.6.10",
 
         "handlebars-template-loader": "^1.0.0",
-        "@types/handlebars": "^4.0.39"
+        "@types/handlebars": "^4.1.0"
     }
 }

--- a/tools/reference-check/vuejs/package.json
+++ b/tools/reference-check/vuejs/package.json
@@ -17,6 +17,6 @@
         "vue-template-compiler": "^2.6.10",
         "sass-loader": "^7.1.0",
         "ts-loader": "^5.3.3",
-        "fork-ts-checker-webpack-plugin": "^1.0.3"
+        "fork-ts-checker-webpack-plugin": "^1.3.0"
     }
 }

--- a/tools/test-engine/coreTestDefinition.js
+++ b/tools/test-engine/coreTestDefinition.js
@@ -277,100 +277,12 @@ class TestGenerator {
         this._tests.push(noJQuery);
 
         /**
-         * jQuery 2 test
-         */
-
-        const jquery2 = Object.assign({}, this.baseTest);
-        jquery2.name = " jQuery 2.x.x";
-        jquery2.specifics = {
-            jsLibrary: ['jquery'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jquery2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint Reference',
-                file: fileContent.package,
-                expr: /stylelint/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard("|:)"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss("|:)"/,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint("|:)"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.noFileContent
-            }
-        ])
-
-        this._tests.push(jquery2);
-
-        /**
          * jQuery 3 Test Definition
          */
         const jquery3 = Object.assign({}, this.baseTest);
         jquery3.name = " jQuery 3.x.x";
         jquery3.specifics = {
-            jsLibrary: ['jquery'],
-            jQueryVersion: 3,
+            jsLibrary: ['jquery@3'],
             force: true
         };
         jquery3.test = this.baseTest.test.concat([{
@@ -450,99 +362,12 @@ class TestGenerator {
         this._tests.push(jquery3);
 
         /**
-         * jQuer 2, pnpjs test
-         */
-        const jqueryPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPnPJS2.name = " jQuery 2.x.x, pnpjs, ";
-        jqueryPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPnPJS2.test = this.baseTest.test.concat([{
-                name: 'jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.noFileContent
-            }
-        ])
-
-        this._tests.push(jqueryPnPJS2);
-
-        /**
          * jquery 3, pnpjs test
          */
         const jqueryPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPnPJS3.name = " jQuery 3.x.x, pnpjs";
         jqueryPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
-            jQueryVersion: 3,
+            jsLibrary: ['jquery@3', '@pnp/pnpjs'],
             force: true
         };
         jqueryPnPJS3.test = this.baseTest.test.concat([{
@@ -622,99 +447,12 @@ class TestGenerator {
         this._tests.push(jqueryPnPJS3);
 
         /**
-         * jquery 2 pnpjs, property control
-         */
-        const jqueryPropPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPropPnPJS2.name = " jQuery 2.x.x, pnp/pnpjs, @pnp/spfx-property-controls";
-        jqueryPropPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPropPnPJS2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: '@pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.noFileContent
-            }
-        ])
-
-        this._tests.push(jqueryPropPnPJS2);
-
-        /**
          * jQUery 3, pnpjs, property control
          */
         const jqueryPropPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPropPnPJS3.name = " jQuery 3.x.x, pnpjs, @pnp/spfx-property-controls";
         jqueryPropPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
-            jQueryVersion: 3,
+            jsLibrary: ['jquery@3', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
             force: true
         };
         jqueryPropPnPJS3.test = this.baseTest.test.concat([{
@@ -886,102 +624,13 @@ class TestGenerator {
         this._tests.push(noJQuery);
 
         /**
-         * jQuery 2 test
-         */
-
-        const jquery2 = Object.assign({}, this.baseTest);
-        jquery2.name = " jQuery 2.x.x, Webpack Bundle Analyser, StyleLint";
-        jquery2.specifics = {
-            jsLibrary: ['jquery'],
-            vetting: ['stylelint', 'webpack-analyzer'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jquery2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jquery2);
-
-        /**
          * jQuery 3 Test Definition
          */
         const jquery3 = Object.assign({}, this.baseTest);
         jquery3.name = " jQuery 3.x.x, Webpack Bundle Analyser, StyleLint";
         jquery3.specifics = {
-            jsLibrary: ['jquery'],
+            jsLibrary: ['jquery@3'],
             vetting: ['stylelint', 'webpack-analyzer'],
-            jQueryVersion: 3,
             force: true
         };
         jquery3.test = this.baseTest.test.concat([{
@@ -1061,101 +710,13 @@ class TestGenerator {
         this._tests.push(jquery3);
 
         /**
-         * jQuer 2, pnpjs test
-         */
-        const jqueryPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPnPJS2.name = " jQuery 2.x.x, pnpjs, Webpack Bundle Analyser, StyleLint";
-        jqueryPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
-            vetting: ['stylelint', 'webpack-analyzer'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPnPJS2.test = this.baseTest.test.concat([{
-                name: 'jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jqueryPnPJS2);
-
-        /**
          * jquery 3, pnpjs test
          */
         const jqueryPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPnPJS3.name = " jQuery 3.x.x, pnpjs, Webpack Bundle Analyser, StyleLint";
         jqueryPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
+            jsLibrary: ['jquery@3', '@pnp/pnpjs'],
             vetting: ['stylelint', 'webpack-analyzer'],
-            jQueryVersion: 3,
             force: true
         };
         jqueryPnPJS3.test = this.baseTest.test.concat([{
@@ -1235,101 +796,13 @@ class TestGenerator {
         this._tests.push(jqueryPnPJS3);
 
         /**
-         * jquery 2 pnpjs, property control
-         */
-        const jqueryPropPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPropPnPJS2.name = " jQuery 2.x.x, pnp/pnpjs, @pnp/spfx-property-controls, Webpack Bundle Analyser, StyleLint";
-        jqueryPropPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
-            vetting: ['stylelint', 'webpack-analyzer'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPropPnPJS2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: '@pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jqueryPropPnPJS2);
-
-        /**
          * jQUery 3, pnpjs, property control
          */
         const jqueryPropPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPropPnPJS3.name = " jQuery 3.x.x, pnpjs, @pnp/spfx-property-controls, Webpack Bundle Analyser, StyleLint";
         jqueryPropPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
+            jsLibrary: ['jquery@3', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
             vetting: ['stylelint', 'webpack-analyzer'],
-            jQueryVersion: 3,
             force: true
         };
         jqueryPropPnPJS3.test = this.baseTest.test.concat([{
@@ -1478,78 +951,13 @@ class TestGenerator {
         this._tests.push(noJQuery);
 
         /**
-         * jQuery 2 test
-         */
-
-        const jquery2 = Object.assign({}, this.baseTest);
-        jquery2.name = " jQuery 2.x.x, WebPack Bundle Analyzer";
-        jquery2.specifics = {
-            jsLibrary: ['jquery'],
-            vetting: ['webpack-analyzer'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jquery2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jquery2);
-
-        /**
          * jQuery 3 Test Definition
          */
         const jquery3 = Object.assign({}, this.baseTest);
         jquery3.name = " jQuery 3.x.x, WebPack Bundle Analyzer";
         jquery3.specifics = {
-            jsLibrary: ['jquery'],
+            jsLibrary: ['jquery@3'],
             vetting: ['webpack-analyzer'],
-            jQueryVersion: 3,
             force: true
         };
         jquery3.test = this.baseTest.test.concat([{
@@ -1605,77 +1013,13 @@ class TestGenerator {
         this._tests.push(jquery3);
 
         /**
-         * jQuer 2, pnpjs test
-         */
-        const jqueryPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPnPJS2.name = " jQuery 2.x.x, pnpjs, WebPack Bundle Analyzer";
-        jqueryPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
-            vetting: ['webpack-analyzer'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPnPJS2.test = this.baseTest.test.concat([{
-                name: 'jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'Webpack analyser',
-                file: fileContent.package,
-                expr: /"webpack-bundle-analyzer"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jqueryPnPJS2);
-
-        /**
          * jquery 3, pnpjs test
          */
         const jqueryPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPnPJS3.name = " jQuery 3.x.x, pnpjs, WebPack Bundle Analyzer";
         jqueryPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
+            jsLibrary: ['jquery@3', '@pnp/pnpjs'],
             vetting: ['webpack-analyzer'],
-            jQueryVersion: 3,
             force: true
         };
         jqueryPnPJS3.test = this.baseTest.test.concat([{
@@ -1731,71 +1075,13 @@ class TestGenerator {
         this._tests.push(jqueryPnPJS3);
 
         /**
-         * jquery 2 pnpjs, property control
-         */
-        const jqueryPropPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPropPnPJS2.name = " jQuery 2.x.x, pnp/pnpjs, @pnp/spfx-property-controls, WebPack Bundle Analyzer";
-        jqueryPropPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
-            vetting: ['webpack-analyzer'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPropPnPJS2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: '@pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            }
-        ])
-
-        this._tests.push(jqueryPropPnPJS2);
-
-        /**
          * jQUery 3, pnpjs, property control
          */
         const jqueryPropPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPropPnPJS3.name = " jQuery 3.x.x, pnpjs, @pnp/spfx-property-controls, WebPack Bundle Analyzer";
         jqueryPropPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
+            jsLibrary: ['jquery@3', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
             vetting: ['webpack-analyzer'],
-            jQueryVersion: 3,
             force: true
         };
         jqueryPropPnPJS3.test = this.baseTest.test.concat([{
@@ -1858,97 +1144,14 @@ class TestGenerator {
         const fileContent = new FileContent();
         const testType = new TestType();
 
-
-        /**
-         * jQuery 2 test
-         */
-        const jquery2 = Object.assign({}, this.baseTest);
-        jquery2.name = " jQuery 2.x.x, StyleLint";
-        jquery2.specifics = {
-            jsLibrary: ['jquery'],
-            vetting: ['stylelint'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jquery2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jquery2);
-
         /**
          * jQuery 3 Test Definition
          */
         const jquery3 = Object.assign({}, this.baseTest);
         jquery3.name = " jQuery 3.x.x, StyleLint";
         jquery3.specifics = {
-            jsLibrary: ['jquery'],
+            jsLibrary: ['jquery@3'],
             vetting: ['stylelint'],
-            jQueryVersion: 3,
             force: true
         };
         jquery3.test = this.baseTest.test.concat([{
@@ -2022,95 +1225,13 @@ class TestGenerator {
         this._tests.push(jquery3);
 
         /**
-         * jQuer 2, pnpjs test
-         */
-        const jqueryPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPnPJS2.name = " jQuery 2.x.x, pnpjs, StyleLint";
-        jqueryPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
-            vetting: ['stylelint'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPnPJS2.test = this.baseTest.test.concat([{
-                name: 'jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jqueryPnPJS2);
-
-        /**
          * jquery 3, pnpjs test
          */
         const jqueryPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPnPJS3.name = " jQuery 3.x.x, pnpjs, StyleLint";
         jqueryPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs'],
+            jsLibrary: ['jquery@3', '@pnp/pnpjs'],
             vetting: ['stylelint'],
-            jQueryVersion: 3,
             force: true
         };
         jqueryPnPJS3.test = this.baseTest.test.concat([{
@@ -2184,95 +1305,13 @@ class TestGenerator {
         this._tests.push(jqueryPnPJS3);
 
         /**
-         * jquery 2 pnpjs, property control
-         */
-        const jqueryPropPnPJS2 = Object.assign({}, this.baseTest);
-        jqueryPropPnPJS2.name = " jQuery 2.x.x, pnp/pnpjs, @pnp/spfx-property-controls, StyleLint";
-        jqueryPropPnPJS2.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
-            vetting: ['stylelint'],
-            jQueryVersion: 2,
-            force: true
-        };
-        jqueryPropPnPJS2.test = this.baseTest.test.concat([{
-                name: 'no jquery 2.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: '@types/jquery 2.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^2\./,
-                type: testType.fileContent
-            },
-            {
-                name: 'no jquery 3.x',
-                file: fileContent.package,
-                expr: /\"jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'no @types/jquery 3.x',
-                file: fileContent.package,
-                expr: /\"@types\/jquery\": \"\^3\./,
-                type: testType.nofileContent
-            },
-            {
-                name: 'pnpjs',
-                file: fileContent.package,
-                expr: /@pnp\/pnpjs/,
-                type: testType.fileContent
-            },
-            {
-                name: '@pnp/spfx-property-controls',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-property-controls/,
-                type: testType.fileContent
-            },
-            {
-                name: 'no @pnp/spfx-controls-react',
-                file: fileContent.package,
-                expr: /@pnp\/spfx-controls-react/,
-                type: testType.noFileContent
-            },
-            {
-                name: 'StyleLint Reference',
-                file: fileContent.package,
-                expr: /"stylelint"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Config Standard',
-                file: fileContent.package,
-                expr: /"stylelint-config-standard"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint SCSS',
-                file: fileContent.package,
-                expr: /"stylelint-scss"/,
-                type: testType.fileContent
-            },
-            {
-                name: 'StyleLint Gulp',
-                file: fileContent.package,
-                expr: /"gulp-stylelint"/,
-                type: testType.fileContent
-            }
-        ])
-
-        this._tests.push(jqueryPropPnPJS2);
-
-        /**
          * jQUery 3, pnpjs, property control
          */
         const jqueryPropPnPJS3 = Object.assign({}, this.baseTest);
         jqueryPropPnPJS3.name = " jQuery 3.x.x, pnpjs, @pnp/spfx-property-controls, StyleLint";
         jqueryPropPnPJS3.specifics = {
-            jsLibrary: ['jquery', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
+            jsLibrary: ['jquery@3', '@pnp/pnpjs', '@pnp/spfx-property-controls'],
             vetting: ['stylelint'],
-            jQueryVersion: 3,
             force: true
         };
         jqueryPropPnPJS3.test = this.baseTest.test.concat([{


### PR DESCRIPTION
#### Category
- [ ] New Feature
- [x] New Framework
- [x] Bugfix
- [ ] Documentation fixed

#### What's in this Pull Request?
- Updated core generator to microsoft/generator-sharepoint 1.8.2
- Remove of jQuery 2 support
- Update of Addon generator references
- Update for jQuery 3.4.1 / @types/jquery 3.3.29
- Update of VueJS references
- Update Office 365 CLI reference for Upgrade checks