### PR TITLE
Added Angular 9 Support

### DIFF
--- a/app/promptConfig.js
+++ b/app/promptConfig.js
@@ -9,13 +9,14 @@ let angularVersion = "";
 const checkAngular = (() => {
 
     try {
-
+    
         const ngVersion = require('@angular/cli/package.json');
-
-        // support for Angular 6/7/8
+        
+        // support for Angular 6/7/8/9
         if (ngVersion.version.startsWith('6') ||
             ngVersion.version.startsWith('7') ||
-            ngVersion.version.startsWith('8')) {
+            ngVersion.version.startsWith('8') || 
+            ngVersion.version.startsWith('9')) {
 
             angularVersion = ` (uses @angular/cli ${ ngVersion.version})`;
 
@@ -25,7 +26,7 @@ const checkAngular = (() => {
         return true;
 
     } catch (error) {
-
+        
         // Angular is disabled because no Valid client could be found
         return true;
 

--- a/generators/angularelements/index.js
+++ b/generators/angularelements/index.js
@@ -64,21 +64,25 @@ module.exports = class extends Generator {
             cwd: path.dirname(angularSolutionPath)
         });
 
+        const ngVersion = require('@angular/cli/package.json');
+        
         const generateComponentOptions = [];
         generateComponentOptions.push('generate');
         generateComponentOptions.push('component');
         generateComponentOptions.push(manifest.componentClassName);
         generateComponentOptions.push('--viewEncapsulation=Emulated');
-        generateComponentOptions.push('--entry-component=true');
+        
+        /** Entry Components are Deprecated in Angular 9 */
+        if(ngVersion.version && parseFloat(ngVersion.version) < 9 ){
+            generateComponentOptions.push('--entry-component=true');
+        }
 
         // ORIGINAME this.spawnCommandSync(`ng generate component ${manifest.componentClassName} -v Native --entry-component`, [], {cwd: angularSolutionPath});
         this.spawnCommandSync('ng', generateComponentOptions, {
             cwd: angularSolutionPath
         });
 
-        // MOve Angular 8 back to ES5
-        const ngVersion = require('@angular/cli/package.json');
-
+        // Move Angular 8 back to ES5
         if (ngVersion.version !== undefined &&
             ngVersion.version.startsWith("8")) {
 
@@ -118,7 +122,8 @@ module.exports = class extends Generator {
             angularSolutionName: angularSolutionName,
             angularSolutionNameKebabCase: paramCase(angularSolutionName),
             componentClassName: manifest.componentClassName,
-            componentClassNameKebabCase: paramCase(manifest.componentClassName)
+            componentClassNameKebabCase: paramCase(manifest.componentClassName),
+            ngVersion: ngVersion.version
         };
 
         util.deployTemplatesToPath(this, ejsInject, this.templatePath('./angular'), angularSolutionPath);

--- a/generators/angularelements/templates/angular/elements-build.js
+++ b/generators/angularelements/templates/angular/elements-build.js
@@ -1,11 +1,21 @@
 const concat = require('concat');
 
-(async function build() {
-  const files = [
+(async function build() {  
+  const files = <% if (parseFloat(ngVersion) < 8.3) { %> [
     './dist/<%= angularSolutionName %>/runtime.js',
     './dist/<%= angularSolutionName %>/polyfills.js',
     './dist/<%= angularSolutionName %>/scripts.js',
     './dist/<%= angularSolutionName %>/main.js'
   ];
+  <% } else { %> [
+      './dist/<%= angularSolutionName %>/runtime-es5.js',
+      './dist/<%= angularSolutionName %>/runtime-es2015.js',
+      './dist/<%= angularSolutionName %>/polyfills-es5.js',
+      './dist/<%= angularSolutionName %>/polyfills-es2015.js',
+      './dist/<%= angularSolutionName %>/main-es5.js',
+      './dist/<%= angularSolutionName %>/main-es2015.js'
+    ];
+  <% } %>
+
   await concat(files, './dist/<%= angularSolutionName %>/bundle.js');
 })();


### PR DESCRIPTION
#### Category
- [x] New Feature
- [ ] New Framework
- [x] Bugfix
- [ ] Documentation fixed
- Related issues: fixes #261 #234 

#### What's in this Pull Request?

I have added angular 9 support, for that, I have made required changes. Also for Angular 8.3 and above `element-build.js` file updated.
From Angular 8.3 build files are generated like `main-es5.js`, `main-es2015.js`, `runtime-es5.js`, `runtime-es2015`, `polyfills-es5.js` and `polyfills-es2015.js`. This will be a conditionally applied so that it can support angular 6/7/8 and 9.

#### Guidance

> This PR will add support for angular 9, also fix angular 8.3 build files bundle changes.
