### PR TITLE
Include Angular Elements Styles in SPFx Webpart

### DIFF
--- a/generators/angularelements/templates/spfx/webpart-onprem19/{componentClassName}.ts
+++ b/generators/angularelements/templates/spfx/webpart-onprem19/{componentClassName}.ts
@@ -9,7 +9,9 @@ import { escape } from '@microsoft/sp-lodash-subset';
 
 import * as strings from '<%= componentStrings %>';
 
+/** Include Angular Elements JS and Style */
 import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/bundle.js';
+require('../../../node_modules/<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
 
 export interface I<%= componentClassName %>Props {
   description: string;

--- a/generators/angularelements/templates/spfx/webpart-spo/{componentClassName}.ts
+++ b/generators/angularelements/templates/spfx/webpart-spo/{componentClassName}.ts
@@ -9,7 +9,9 @@ import { escape } from '@microsoft/sp-lodash-subset';
 
 import * as strings from '<%= componentStrings %>';
 
+/** Include Angular Elements JS and Style */
 import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/bundle';
+require('../../../node_modules/<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
 
 export interface I<%= componentClassName %>Props {
   description: string;


### PR DESCRIPTION
#### Category
- [ ] New Feature
- [ ] New Framework
- [x] Bugfix
- [ ] Documentation fixed
- Related issues: fixes #254 

#### What's in this Pull Request?

Currently when we generate angular-elements project with spfx-webpart, it only includes the `bundle.js` of angular-element in webpart, but it doesn't include css file. so if angular-element contains the styles, this is not getting applied in SPFx webpart. 

This PR, includes the angular-element's `styles.css` file in `SPFx-webpart.ts`. as below :
```js
require('../../../node_modules/<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
```

#### Guidance

Include angular-elements `styles.css` file in `SPFx-webpart.ts` file