### PR TITLE
Added Angular 10 support

### DIFF
--- a/app/promptConfig.js
+++ b/app/promptConfig.js
@@ -9,24 +9,18 @@ let angularVersion = "";
 const checkAngular = (() => {
 
     try {
-    
         const ngVersion = require('@angular/cli/package.json');
         
-        // support for Angular 6/7/8/9
-        if (ngVersion.version.startsWith('6') ||
-            ngVersion.version.startsWith('7') ||
-            ngVersion.version.startsWith('8') || 
-            ngVersion.version.startsWith('9')) {
-
-            angularVersion = ` (uses @angular/cli ${ ngVersion.version})`;
-
+        // support for Angular 6 and all above versions
+        if ((+ngVersion.version.split('.')[0]) >= 6) {
+            angularVersion = ` (uses @angular/cli ${ngVersion.version})`;
             return false;
         };
 
         return true;
 
     } catch (error) {
-        
+
         // Angular is disabled because no Valid client could be found
         return true;
 
@@ -35,17 +29,17 @@ const checkAngular = (() => {
 })();
 
 const supportedSPFxTargets = [{
-        name: 'SharePoint Online only (latest)',
-        value: 'spo'
-    },
-    {
-        name: 'SharePoint 2019 onwards, including SharePoint Online',
-        value: 'onprem19'
-    },
-    {
-        name: 'SharePoint 2016 onwards, including 2019 and SharePoint Online',
-        value: 'onprem'
-    }
+    name: 'SharePoint Online only (latest)',
+    value: 'spo'
+},
+{
+    name: 'SharePoint 2019 onwards, including SharePoint Online',
+    value: 'onprem19'
+},
+{
+    name: 'SharePoint 2016 onwards, including 2019 and SharePoint Online',
+    value: 'onprem'
+}
 ];
 
 // if environment optiosn have been specified

--- a/generators/angularelements/templates/angular/elements-build.js
+++ b/generators/angularelements/templates/angular/elements-build.js
@@ -1,21 +1,35 @@
 const concat = require('concat');
+const fs = require('fs');
 
-(async function build() {  
-  const files = <% if (parseFloat(ngVersion) < 8.3) { %> [
-    './dist/<%= angularSolutionName %>/runtime.js',
-    './dist/<%= angularSolutionName %>/polyfills.js',
-    './dist/<%= angularSolutionName %>/scripts.js',
-    './dist/<%= angularSolutionName %>/main.js'
-  ];
-  <% } else { %> [
-      './dist/<%= angularSolutionName %>/runtime-es5.js',
-      './dist/<%= angularSolutionName %>/runtime-es2015.js',
-      './dist/<%= angularSolutionName %>/polyfills-es5.js',
-      './dist/<%= angularSolutionName %>/polyfills-es2015.js',
-      './dist/<%= angularSolutionName %>/main-es5.js',
-      './dist/<%= angularSolutionName %>/main-es2015.js'
-    ];
-  <% } %>
+/**
+ * Get the list of files from given directory with specified file extension. 
+ * @param {string} directoryPath
+ * @param {string} fileExtension
+ */
+function getFilesFromDirByType(directoryPath, fileExtension) {
+  return new Promise((resolve, reject) => {
+    return fs.readdir(directoryPath, function (err, files) {
+      if (err) {
+        return reject(`ERR! ${err.code}: no such file or directory ${err.path}`);
+      }
+      return resolve(files.filter(f => f.endsWith(`.${fileExtension}`)));
+    });
+  });
+}
 
-  await concat(files, './dist/<%= angularSolutionName %>/bundle.js');
+(async function build() {
+  
+  /**
+   * Get the JS files from `./dist/<%= angularSolutionName %>/` directory and combine it into `bundle.js`
+   * This will give support for angular v6 and all above versions.
+   */
+ 
+  try {
+    let directoryPath = './dist/<%= angularSolutionName %>/';
+    let files = await getFilesFromDirByType(directoryPath, 'js');
+    files = files.map(file => directoryPath + file);
+    await concat(files, './dist/<%= angularSolutionName %>/bundle.js');
+  } catch (error) {
+    console.log(error);
+  }
 })();


### PR DESCRIPTION
Changes have been made in such a way that it will support angular v6 and all the above and future versions.

#### Category
- [x] New Feature
- [ ] New Framework
- [ ] Bugfix
- [ ] Documentation fixed

#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs that are being fixed.

In Angular v6 to v8, build files are generated as `main.js`, `runtime.js`, `polyfills.js`, 

while from angular v8.3 it is generated as `main-es5.js`, `runtime-es5.js`, `polyfills-es5.js`, `main-es2015.js`, `runtime-es2015.js`, `polyfills-es2015.js` to give support for evergreen browsers and older browsers.  

In Angular v10 release above thing is become dynamic,  it will generate the build files based the specified browser in `.browserslistrc`. 
- If in `.browserslistrc` contains only evergreen browsers then it will generate  `main.js`, `runtime.js`, `polyfills.js` files. 
- If you add support for the older browser in your application like `IE 11` by removing `not` in the `.browserslistrc` file then it will generate `main-es5.js`, `runtime-es5.js`, `polyfills-es5.js`, `main-es2015.js`, `runtime-es2015.js`, `polyfills-es2015.js`. 

So to add support for all types of build files, In this PR we are getting files from the `dist` folder programmatically and using it to generate `bundle.js` file.
