### PR TITLE
feat(angular): generate angular bundle with source map for debugging angular element in SPFx webpart

### DIFF
--- a/generators/angularelements/index.js
+++ b/generators/angularelements/index.js
@@ -109,7 +109,7 @@ module.exports = class extends Generator {
         );
 
         //added --optimization=false to solve the issue of over minification of angular element bundle
-        pkg.scripts['bundle'] = 'ng build --prod --output-hashing none --optimization=false && node elements-build.js';
+        pkg.scripts['bundle'] = 'ng build --prod --output-hashing none --optimization=false --single-bundle --source-map';
 
         pkg.dependencies['concat'] = '^1.0.3';
         pkg.dependencies['@webcomponents/custom-elements'] = '^1.2.0';
@@ -174,6 +174,10 @@ module.exports = class extends Generator {
             )
 
             this.spawnCommandSync('ng', ['add', '@angular/elements'], {
+                cwd: angularSolutionPath
+            });
+
+            this.spawnCommandSync('ng', ['add', 'ngx-build-plus'], {
                 cwd: angularSolutionPath
             });
 

--- a/generators/angularelements/templates/spfx/webpart-onprem19/{componentClassName}.ts
+++ b/generators/angularelements/templates/spfx/webpart-onprem19/{componentClassName}.ts
@@ -10,8 +10,9 @@ import { escape } from '@microsoft/sp-lodash-subset';
 import * as strings from '<%= componentStrings %>';
 
 /** Include Angular Elements JS and Style */
-import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/bundle.js';
-require('../../../node_modules/<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
+import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/main';
+import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/polyfills';
+require('<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
 
 export interface I<%= componentClassName %>Props {
   description: string;

--- a/generators/angularelements/templates/spfx/webpart-spo/{componentClassName}.ts
+++ b/generators/angularelements/templates/spfx/webpart-spo/{componentClassName}.ts
@@ -10,8 +10,9 @@ import { escape } from '@microsoft/sp-lodash-subset';
 import * as strings from '<%= componentStrings %>';
 
 /** Include Angular Elements JS and Style */
-import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/bundle';
-require('../../../node_modules/<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
+import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/main';
+import '<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/polyfills';
+require('<%= angularSolutionNameKebabCase %>/dist/<%= angularSolutionName %>/styles.css');
 
 export interface I<%= componentClassName %>Props {
   description: string;


### PR DESCRIPTION
#### Category
- [x] New Feature
- [ ] New Framework
- [ ] Bugfix
- [ ] Documentation fixed
- Related issues: #278 

#### What's in this Pull Request?

This PR will add a feature to generate a single angular bundle with a source map, which allows debugging the angular element component in SPFx Web part. Also, we will generate single bundle when `ng build` command is executed, So we don't require `node element-build.js`.
Separate `polyfills.js` is expected, which will be included in webpart.

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

